### PR TITLE
Conditional anaphora stage + ChunkRAG source links

### DIFF
--- a/src/meno_core/api/main.py
+++ b/src/meno_core/api/main.py
@@ -435,6 +435,8 @@ async def chat_completions(request: OAIChatCompletionsRequest, raw_request: Fast
         logger.exception("Anaphora resolution failed", exc_info=resolve_error)
         resolved_query = expanded_query
     request_timings_ms["resolve"] = round((time.perf_counter() - resolve_started_at) * 1000, 2)
+    request_timings_ms["_anaphora_changed"] = (resolved_query != expanded_query)
+    request_timings_ms["_resolved_query"] = resolved_query
     request_timings_ms["request_prepare"] = round(
         request_timings_ms["prompt_build"] + request_timings_ms["expand"] + request_timings_ms["resolve"],
         2,
@@ -630,10 +632,15 @@ async def chat_completions(request: OAIChatCompletionsRequest, raw_request: Fast
                 yield emit_stage(StageName.ABBREVIATION_EXPANSION.value, StageStatus.COMPLETED.value, duration_ms=expand_ms)
 
             resolve_ms = request_timings_ms.get("resolve")
-            if resolve_ms is not None:
+            if resolve_ms is not None and request_timings_ms.get("_anaphora_changed"):
                 timer.stages[StageName.ANAPHORA_RESOLUTION.value] = resolve_ms
                 yield emit_stage(StageName.ANAPHORA_RESOLUTION.value, StageStatus.STARTED.value)
-                yield emit_stage(StageName.ANAPHORA_RESOLUTION.value, StageStatus.COMPLETED.value, duration_ms=resolve_ms)
+                yield emit_stage(
+                    StageName.ANAPHORA_RESOLUTION.value,
+                    StageStatus.COMPLETED.value,
+                    duration_ms=resolve_ms,
+                    detail={"resolved_query": request_timings_ms.get("_resolved_query", "")},
+                )
 
         # Role chunk
         first = mk_chunk({"role": "assistant"})
@@ -662,6 +669,23 @@ async def chat_completions(request: OAIChatCompletionsRequest, raw_request: Fast
                 splitter = ThinkingTokenSplitter()
 
                 async for piece in iter_pieces():
+                    # Source references from orchestrator (ChunkRAG)
+                    if isinstance(piece, dict) and "_sources" in piece:
+                        sources_list = piece["_sources"]
+                        if emit_stages and sources_list:
+                            yield f"event: sources\ndata: {json.dumps({'sources': sources_list}, ensure_ascii=False)}\n\n"
+                        if sources_list:
+                            links_md = "\n\n---\n**Источники:**\n"
+                            for src in sources_list:
+                                title = src.get("document_title", "")
+                                url = src.get("source_url", "")
+                                if url:
+                                    links_md += f"- [{title}]({url})\n" if title else f"- {url}\n"
+                            accumulated.append(links_md)
+                            data = mk_chunk({"content": links_md})
+                            yield f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+                        continue
+
                     # Stage event dicts from orchestrator.answer_stream()
                     if isinstance(piece, dict) and "_stage" in piece:
                         if emit_stages:

--- a/src/meno_core/api/main.py
+++ b/src/meno_core/api/main.py
@@ -435,8 +435,7 @@ async def chat_completions(request: OAIChatCompletionsRequest, raw_request: Fast
         logger.exception("Anaphora resolution failed", exc_info=resolve_error)
         resolved_query = expanded_query
     request_timings_ms["resolve"] = round((time.perf_counter() - resolve_started_at) * 1000, 2)
-    request_timings_ms["_anaphora_changed"] = (resolved_query != expanded_query)
-    request_timings_ms["_resolved_query"] = resolved_query
+    anaphora_changed = (resolved_query != expanded_query)
     request_timings_ms["request_prepare"] = round(
         request_timings_ms["prompt_build"] + request_timings_ms["expand"] + request_timings_ms["resolve"],
         2,
@@ -632,14 +631,14 @@ async def chat_completions(request: OAIChatCompletionsRequest, raw_request: Fast
                 yield emit_stage(StageName.ABBREVIATION_EXPANSION.value, StageStatus.COMPLETED.value, duration_ms=expand_ms)
 
             resolve_ms = request_timings_ms.get("resolve")
-            if resolve_ms is not None and request_timings_ms.get("_anaphora_changed"):
+            if resolve_ms is not None and anaphora_changed:
                 timer.stages[StageName.ANAPHORA_RESOLUTION.value] = resolve_ms
                 yield emit_stage(StageName.ANAPHORA_RESOLUTION.value, StageStatus.STARTED.value)
                 yield emit_stage(
                     StageName.ANAPHORA_RESOLUTION.value,
                     StageStatus.COMPLETED.value,
                     duration_ms=resolve_ms,
-                    detail={"resolved_query": request_timings_ms.get("_resolved_query", "")},
+                    detail={"resolved_query": resolved_query},
                 )
 
         # Role chunk

--- a/src/meno_core/api/pipeline_stages.py
+++ b/src/meno_core/api/pipeline_stages.py
@@ -23,8 +23,6 @@ class StageName(str, Enum):
     GRAPH_GLOBAL_RETRIEVAL = "graph_global_retrieval"
     VECTOR_RETRIEVAL = "vector_retrieval"
     CONTEXT_BUILD = "context_build"
-    LINK_ADDITION = "link_addition"
-    LINK_CORRECTION = "link_correction"
 
 
 class StageStatus(str, Enum):

--- a/src/meno_core/core/rag/orchestration/orchestrator.py
+++ b/src/meno_core/core/rag/orchestration/orchestrator.py
@@ -497,6 +497,14 @@ class ChunkRagOrchestrator:
                 "_stage": "generation", "status": "completed", "duration_ms": generation_ms,
             }
 
+            if sources:
+                yield {
+                    "_sources": [
+                        {"document_title": s.document_title, "source_url": s.source_url}
+                        for s in sources if s.source_url
+                    ]
+                }
+
             pipeline_logger.info(
                 "request-finished request_id=%s session_id=%s total_ms=%s generation_ms=%s stream=true sources=%s",
                 request_id, session_id, total_ms, generation_ms, len(sources),


### PR DESCRIPTION
## Summary
- **Anaphora resolution stage** now only appears in the UI when it actually changes the query (skips the 0ms no-op display)
- **ChunkRAG source links**: after generation, source URLs from retrieved chunks are emitted as an SSE `sources` event and appended to the answer as clickable markdown links
- Removed unused `LINK_ADDITION` / `LINK_CORRECTION` stage enum values

## Test plan
- [ ] Send a first message (no history) — verify "Разрешение ссылок" stage does NOT appear
- [ ] Send a follow-up with pronouns referencing prior context — verify the stage appears with resolved query detail
- [ ] Use ChunkRAG engine — verify source links appear in the response text and as a separate SSE `sources` event
- [ ] Use LightRAG engine — verify response works as before without source links

🤖 Generated with [Claude Code](https://claude.com/claude-code)